### PR TITLE
Broadway portconfig via environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN dnf --setopt=install_weak_deps=False install -y -- \
     curl --location --output /tmp/s6-overlay-some-arch.tar.xz -- \
          https://github.com/just-containers/s6-overlay/releases/download/v"$S6_OVERLAY_VERSION"/s6-overlay-"$(arch)"-"$S6_OVERLAY_VERSION".tar.xz && \
     tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
-    tar -C / -Jxpf /tmp/s6-overlay-some-arch.tar.xz && \
-    rm -rf -- /tmp/**
+    tar -C / -Jxpf /tmp/s6-overlay-some-arch.tar.xz
 ENV TERM=xterm-256color\
     S6_KEEP_ENV=1 \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
@@ -29,6 +28,7 @@ ENTRYPOINT [ "/init" ]
 COPY ./fs /
 ENV GDK_BACKEND=broadway \
     NO_AT_BRIDGE=1 \
+    BROADWAY_PORT=8080 \
     VIRT_CONN=qemu:///system \
     DATA_DIR=/data \
     WIN_DRIVER='https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,22 @@
 node {
     def app
+    def dockerImageName
 
     stage('Clone repository') { // for display purposes
         cleanWs()
-        //git branch: 'main', changelog: false, poll: false, url: 'https://github.com/dddmaster/docker_samba_ad.git'
-        checkout scm
+        def s = checkout scm
+        def splitGitUrl = s.GIT_URL.split('/');
+        dockerImageName = splitGitUrl[splitGitUrl.size() - 2] + "/" + splitGitUrl[splitGitUrl.size() - 1].replace(".git", "")
     }
     stage('Build') {
-        app = docker.build "dddmaster/windows-in-docker"
+        app = docker.build dockerImageName
     }
 
     stage('push') {
-        // This step should not normally be used in your script. Consult the inline help for details.
         withDockerRegistry(credentialsId: 'dockerhub') {
             app.push('latest')
         }
+
+        cleanWs()
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,19 @@
+node {
+    def app
+
+    stage('Clone repository') { // for display purposes
+        cleanWs()
+        //git branch: 'main', changelog: false, poll: false, url: 'https://github.com/dddmaster/docker_samba_ad.git'
+        checkout scm
+    }
+    stage('Build') {
+        app = docker.build "dddmaster/windows-in-docker"
+    }
+
+    stage('push') {
+        // This step should not normally be used in your script. Consult the inline help for details.
+        withDockerRegistry(credentialsId: 'dockerhub') {
+            app.push('latest')
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Periodically dump latest `virtio-win.iso` into `/data`
 
 1. Install `libvirt-daemon` under **linux host**, ie `apt install -- libvirt-daemon-system`.
 
-2. Run the following `docker-compose`.
+2. Adjust the broadway_port variable to define your own port. Default is 8080
+
+3. Run the following `docker-compose`.
 
 ```yaml
 ---
@@ -39,8 +41,10 @@ services:
       # Make sure DATA_DIR is the same across the three `${DATA_DIR}`s
       # The windows drivers are also downloaded under here.
       DATA_DIR: "${DATA_DIR}"
+      BROADWAY_PORT: "${BROADWAY_PORT}"
+  
     ports:
-      - 80:8080
+      - 80:${BROADWAY_PORT}
     volumes:
       - /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock:ro
       - "${DATA_DIR}:${DATA_DIR}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # [Windows in Docker](https://ms-jpq.github.io/windows-in-docker)
+## BRANCH CHANGES ##
+
+Use port environment variable BROADWAY_PORT to define what port is used internally in case you want to use host as network or whatever.
+
+##
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/msjpq/windows-in-docker.svg)](https://hub.docker.com/r/msjpq/windows-in-docker/)
 

--- a/fs/etc/services.d/broadwayd/data/check
+++ b/fs/etc/services.d/broadwayd/data/check
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from os import sep
+from os import environ
 from pathlib import PurePath
 from subprocess import call
 from time import sleep
@@ -13,7 +14,7 @@ while call(
         "1",
         "--head",
         "--",
-        "localhost:8080",
+        "localhost:" + environ.get('BROADWAY_PORT'),
     )
 ):
     sleep(1)

--- a/fs/etc/services.d/broadwayd/run
+++ b/fs/etc/services.d/broadwayd/run
@@ -1,11 +1,3 @@
-#!/usr/bin/env python3
+#!/bin/bash
 
-from os import execl, sep
-from pathlib import PurePath
-
-arg0 = PurePath(sep) / "command" / "s6-notifyoncheck"
-execl(
-    arg0,
-    arg0,
-    PurePath(sep) / "bin" / "broadwayd",
-)
+/command/s6-notifyoncheck /bin/broadwayd --port $BROADWAY_PORT


### PR DESCRIPTION
Altered broadway s6 configuration to utilize a port environment variable for the http listening port.
the variable defaults back to 8080 if nothing is set.
With this you can configure the used port if you dont want to use port mapping and expose the container directly.
The Jenkinsfile is not mandatory and only for convenience.